### PR TITLE
Improve mobile menu navigation and overlay behavior

### DIFF
--- a/app/_components/Header/_component/MenuIttem.jsx
+++ b/app/_components/Header/_component/MenuIttem.jsx
@@ -1,10 +1,24 @@
-import Link from 'next/link';
 import React from 'react';
+import { useRouter } from 'next/navigation';
 
-const MenuIttem = ({name, href}) => {
+const MenuIttem = ({ name, href, onNavigate }) => {
+  const router = useRouter();
+
+  const handleClick = async (e) => {
+    // ensure navigation happens programmatically first
+    e.preventDefault();
+    try {
+      await router.push(href);
+    } finally {
+      if (typeof onNavigate === 'function') onNavigate();
+    }
+  };
+
   return (
     <li>
-        <Link href={`${href}`} className="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-900 md:p-0 md:dark:text-green-500" aria-current="page">{name}</Link>
+      <a href={href} onClick={handleClick} className="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-900 md:p-0 md:dark:text-green-500" aria-current="page">
+        {name}
+      </a>
     </li>
   );
 };

--- a/app/_components/Header/page.jsx
+++ b/app/_components/Header/page.jsx
@@ -37,15 +37,15 @@ export default function Header () {
         </svg>
     </button>
   </div>
-  <div className={`items-center justify-between ${menuView ? 'flex' : 'hidden'} w-full md:flex md:w-auto md:order-1`} id="navbar-sticky">
+  <div className={`items-center justify-between ${menuView ? 'flex' : 'hidden'} w-full md:flex md:w-auto md:order-1 relative z-30`} id="navbar-sticky">
     <ul className="flex flex-col gap-1 p-4 md:p-0 mt-4 font-medium border border-gray-100 rounded-lg bg-gray-50 md:space-x-8 rtl:space-x-reverse md:flex-row md:mt-0 md:border-0 md:bg-white dark:bg-gray-800 md:dark:bg-gray-900 dark:border-gray-700 w-full">
       
       
-      <MenuIttem name="Головна" href="/"   />
-      <MenuIttem name="Послуги" href="/categories/likuvannya-korenevikh-kanaliv"  />
-      <MenuIttem name="Лікарі" href="/doctors/vasylyaka-serhiy"  />
-      <MenuIttem name="Ціни" href="/prices"  />
-      <MenuIttem name="Контакти" href="/about"  />
+  <MenuIttem name="Головна" href="/" onNavigate={() => setMenuView(false)} />
+  <MenuIttem name="Послуги" href="/categories/likuvannya-korenevikh-kanaliv" onNavigate={() => setMenuView(false)} />
+  <MenuIttem name="Лікарі" href="/doctors/vasylyaka-serhiy" onNavigate={() => setMenuView(false)} />
+  <MenuIttem name="Ціни" href="/prices" onNavigate={() => setMenuView(false)} />
+  <MenuIttem name="Контакти" href="/about" onNavigate={() => setMenuView(false)} />
       
       
       
@@ -54,6 +54,15 @@ export default function Header () {
   </div>
   </div>
 </nav>
+
+      {/* Mobile overlay: covers the page outside the menu and closes menu on click */}
+      {menuView && (
+        <div
+          className="fixed inset-0 bg-black/40 md:hidden z-10"
+          onClick={() => setMenuView(false)}
+          aria-hidden="true"
+        />
+      )}
 
         </div>
     );

--- a/lib/setting.js
+++ b/lib/setting.js
@@ -8,7 +8,7 @@ export const setting = {
     phone_primery:  "+38-098-79-91-200",
     phone_secondary: "+38-099-09-59-550",
     schedulle: "Пн-Пт з 9.00 до 20.00",
-    web_version: "2.5.2",
+    web_version: "2.5.3",
     url_cannonical: "https://poltava-dent.com.ua/",
     url: "https://poltava-dent.com.ua/",
     email: "poltava.dent1@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stomat-new-poltavadent",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "scripts": {
     "debuger": "set NODE_OPTIONS=--inspect && next dev",


### PR DESCRIPTION
MenuIttem now uses programmatic navigation and supports an onNavigate callback to close the menu after navigation. Header adds a mobile overlay that closes the menu when clicked, improving UX. Updated version to 2.5.3 in settings and package.json.
- Змінити MenuIttem: використовувати програмну навігацію (router.push) і викликати callback `onNavigate()` після завершення навігації.
- Передати `onNavigate={() => setMenuView(false)}` при рендері MenuIttem у Header.
- Додати мобільний оверлей (fixed inset-0 bg-black/40 md:hidden z-10), який закриває меню при кліку; зробити меню вище за оверлей (z-30).
- Виправити z-index оверлею, щоб не перекривати саме меню.
- (Опціонально) Заблокувати скрол сторінки при відкритому меню через body overflow toggle.