### PR TITLE
Set page to use dynamic rendering

### DIFF
--- a/app/(routes)/categories/[category]/page.jsx
+++ b/app/(routes)/categories/[category]/page.jsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { getAllInfoServices } from '@/app/_services/graphQL_custom/QueryGraphQL';
 import { fetcher } from '@/app/_services/fetcher';
 import { setting } from '@/lib/setting';


### PR DESCRIPTION
Added 'export const dynamic = "force-dynamic"' to ensure the category page is rendered dynamically. This change may be needed for up-to-date data or to support dynamic routing features.