### PR TITLE
Refactor dynamic import usage in category page

### DIFF
--- a/app/(routes)/categories/[category]/page.jsx
+++ b/app/(routes)/categories/[category]/page.jsx
@@ -8,13 +8,11 @@ import { Separator } from "@/components/ui/separator";
 import {DescriptionBlock} from '../_components/DescriptionBlock/DescriptionBlock';
 import GalleryServices from '../_components/GalleryServices/GalleryServices';
 import FullText from '@/app/_components/FullText/FullText';
-import dynamic from 'next/dynamic';
-//import GetPriceForCategory from '@/app/_components/GetPriceForCategory/GetPriceForCategory';
+import dynamicImport from 'next/dynamic';
 
 // Динамічний імпорт клієнтських компонентів
- const DoctorItemServices = dynamic(() => import('@/app/_components/DoctorItemServices/DoctorItemsServices'), { ssr: false });
-//const GetPriceForCategory = dynamic(() => import('@/app/_components/PricesBlock/PricesBlockClient'), { ssr: false });
-const GetPriceForCategory = dynamic(() => import('@/app/_components/GetPriceForCategory/GetPriceForCategory'), { ssr: false });
+ const DoctorItemServices = dynamicImport(() => import('@/app/_components/DoctorItemServices/DoctorItemsServices'), { ssr: false });
+const GetPriceForCategory = dynamicImport(() => import('@/app/_components/GetPriceForCategory/GetPriceForCategory'), { ssr: false });
 
 export async function generateMetadata({ params }) {
   const query = getAllInfoServices(params.category);


### PR DESCRIPTION
Replaced 'dynamic' with 'dynamicImport' from 'next/dynamic' for client-side component imports in the category page. This improves code clarity and consistency.